### PR TITLE
feat: Improve relative time on notes

### DIFF
--- a/components/Note/Note.js
+++ b/components/Note/Note.js
@@ -22,7 +22,7 @@ import {
 } from "../../icons/StemstrIcon";
 import useNostr from "../../nostr/hooks/useNostr";
 import { useProfile } from "../../nostr/hooks/useProfile";
-import { dateToUnix } from "../../nostr/utils";
+import { getRelativeTimeString } from "../../nostr/utils";
 import DownloadSoundButton from "../DownloadSoundButton/DownloadSoundButton";
 import NoteAction from "../NoteAction/NoteAction";
 import SoundPlayer from "../SoundPlayer/SoundPlayer";
@@ -98,10 +98,7 @@ export default function Note(props) {
             </Text>
             <Text size="sm" color="rgba(255, 255, 255, 0.38)">
               ·{" "}
-              {Math.floor(
-                (dateToUnix(new Date()) - note.event.created_at) / 60
-              )}
-              m
+              {getRelativeTimeString(note.event.created_at)}
             </Text>
           </Group>
           <Group position="right">

--- a/nostr/utils.ts
+++ b/nostr/utils.ts
@@ -61,3 +61,29 @@ export const isHexPubkey = (hexOrNpub: string): boolean => {
 export const abbreviateKey = (key: string): string => {
   return `${key.slice(0, 12)}...${key.slice(-12)}`;
 };
+
+export const getRelativeTimeString = (timestamp: number) => {
+  const nowInSeconds = Math.floor(Date.now() / 1000);
+  const diffInSeconds = nowInSeconds - timestamp;
+
+  const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+  if (diffInSeconds < 60) {
+    return rtf.format(-diffInSeconds, 'second');
+  } else if (diffInSeconds < 3600) {
+    const minutes = Math.floor(diffInSeconds / 60);
+    return rtf.format(-minutes, 'minute');
+  } else if (diffInSeconds < 86400) {
+    const hours = Math.floor(diffInSeconds / 3600);
+    return rtf.format(-hours, 'hour');
+  } else if (diffInSeconds < 604800){
+    const days = Math.floor(diffInSeconds / 86400);
+    return rtf.format(-days, 'day');
+  } else if (diffInSeconds < 2628288){
+    const weeks = Math.floor(diffInSeconds / 604800);
+    return rtf.format(-weeks, 'week');
+  } else {
+    const months = Math.floor(diffInSeconds / 2628288);
+    return rtf.format(-months, 'month');
+  }
+}


### PR DESCRIPTION
Uses [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat) to format relative time on notes.

Example outputs:
```
30 seconds ago
5 minutes ago
1 hour ago
2 days ago
2 weeks ago
last month
2 months ago
```
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/4248167/230782716-6aaa671f-1818-4521-977d-6e06de36b83e.png">

