### PR TITLE
fix: mobile upload file picker

### DIFF
--- a/utils/media.ts
+++ b/utils/media.ts
@@ -53,7 +53,6 @@ export const acceptedMimeTypes: string[] = [
   "audio/vorbis",
   "audio/wav",
   "audio/wave",
-  "audio/webm",
   "audio/x-aif",
   "audio/x-aifc",
   "audio/x-aiff",


### PR DESCRIPTION
Removes the mimetype that made iOS display this popup, as opposed to immediately launching the filepicker.

<img width=200 src="https://user-images.githubusercontent.com/4248167/232614075-92cf118b-e349-4031-87b0-9ed79a84e5ca.png">
