### PR TITLE
fix note layer header layout

### DIFF
--- a/components/HomeFeed/HomeFeed.tsx
+++ b/components/HomeFeed/HomeFeed.tsx
@@ -4,9 +4,11 @@ import { useHomeFeed } from "ndk/hooks/useHomeFeed";
 import { VariableSizeList, areEqual } from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
 import { Box } from "@mantine/core";
+import { useMediaQuery } from "@mantine/hooks";
 
 export default function HomeFeed() {
   const headerHeight = 68;
+  const footerHeight = useMediaQuery("(max-width: 480px)") ? 64 : 96;
   const feed = useHomeFeed();
   const events = feed.filter(
     (event) => !event.tags.find((tag) => tag[0] === "e")
@@ -27,11 +29,14 @@ export default function HomeFeed() {
       const gapSize = 16;
       const topPosition = style.top + gapSize * index;
       const isLastEvent = index === events.length - 1;
-
-      useEffect(() => {
+      const updateRowHeight = () => {
         if (rowRef.current) {
           setRowHeight(index, rowRef.current.clientHeight);
         }
+      };
+
+      useEffect(() => {
+        updateRowHeight();
       }, [rowRef]);
 
       return (
@@ -50,7 +55,11 @@ export default function HomeFeed() {
             ref={rowRef}
             style={{ paddingBottom: isLastEvent ? gapSize : 0 }}
           >
-            <FeedNote key={event.id} event={event} />
+            <FeedNote
+              key={event.id}
+              event={event}
+              onUserDataLoad={updateRowHeight}
+            />
           </div>
         </Box>
       );
@@ -62,7 +71,7 @@ export default function HomeFeed() {
     <AutoSizer style={{ height: `calc(100vh - ${headerHeight}px` }}>
       {({ height, width }: { height: number; width: number }) => (
         <VariableSizeList
-          height={height - 164}
+          height={height - headerHeight - footerHeight}
           itemCount={events.length}
           itemSize={getRowHeight}
           width={width}

--- a/components/Note/Note.js
+++ b/components/Note/Note.js
@@ -18,10 +18,11 @@ import { useNote } from "ndk/hooks/useNote";
 import { useNDK } from "ndk/NDKProvider";
 import { formatETag, parseEventTags } from "ndk/utils";
 import { NDKEvent } from "@nostr-dev-kit/ndk";
+import { noop } from "../../utils/common";
 
 const Note = (props) => {
   const { ndk } = useNDK();
-  const { event, type, onUserDataLoad } = props;
+  const { event, type, onUserDataLoad = noop } = props;
   const note = useNote({ event });
   const { classes } = useStyles();
   const router = useRouter();

--- a/components/Note/Note.js
+++ b/components/Note/Note.js
@@ -21,7 +21,7 @@ import { NDKEvent } from "@nostr-dev-kit/ndk";
 
 const Note = (props) => {
   const { ndk } = useNDK();
-  const { event, type } = props;
+  const { event, type, onUserDataLoad } = props;
   const note = useNote({ event });
   const { classes } = useStyles();
   const router = useRouter();
@@ -84,6 +84,12 @@ const Note = (props) => {
       }
     }
   }, [note.reactions.length, auth.pk]);
+
+  useEffect(() => {
+    if (userData) {
+      onUserDataLoad();
+    }
+  }, [userData]);
 
   const handleClick = () => {
     router.push(`/thread/${note.event.id}`);

--- a/components/NoteHeader/NoteHeader.js
+++ b/components/NoteHeader/NoteHeader.js
@@ -1,6 +1,6 @@
 import { Anchor, Avatar, Center, Group, Text, Stack } from "@mantine/core";
 import { useMediaQuery } from "@mantine/hooks";
-import { MoreIcon, VerifiedIcon } from "../../icons/StemstrIcon";
+import { VerifiedIcon } from "../../icons/StemstrIcon";
 import DownloadSoundButton from "../DownloadSoundButton/DownloadSoundButton";
 import Link from "next/link";
 import withStopClickPropagation from "../../utils/hoc/withStopClickPropagation";
@@ -15,9 +15,12 @@ const UserDetailsAnchorWrapper = ({ note, children }) => (
       ":hover": {
         textDecoration: "none",
       },
+      overflow: "hidden",
     }}
   >
-    {children}
+    <Group spacing={6} sx={{ flexWrap: "nowrap" }}>
+      {children}
+    </Group>
   </Anchor>
 );
 
@@ -33,49 +36,70 @@ const UserDetailsDisplayName = ({ note, userData, ...rest }) => (
   </Text>
 );
 
-const UserDetailsName = ({ userData }) => (
-  <Text size="xs" color="rgba(255, 255, 255, 0.74)">
+const UserDetailsName = ({ userData, ...rest }) => (
+  <Text size="xs" color="rgba(255, 255, 255, 0.74)" {...rest}>
     {userData?.name ? `@${userData.name}` : ""}
   </Text>
 );
 
 const RelativeTime = ({ note, ...rest }) => (
-  <Text size="sm" color="rgba(255, 255, 255, 0.38)" {...rest}>
+  <Text
+    size="sm"
+    color="rgba(255, 255, 255, 0.38)"
+    sx={{ whiteSpace: "nowrap" }}
+    {...rest}
+  >
     · {getRelativeTimeString(note.event.created_at)}
   </Text>
 );
 
-const DesktopUserDetails = ({ note, userData }) => (
-  <Group spacing={6}>
+const DesktopUserDetails = ({ note, userData, sx }) => (
+  <Group spacing={6} sx={sx}>
     <UserDetailsAnchorWrapper note={note}>
-      <Group spacing={6}>
-        <UserDetailsAvatar userData={userData} />
-        <UserDetailsDisplayName size="lg" note={note} userData={userData} />
-        <VerifiedIcon width={14} height={14} />
-        <UserDetailsName userData={userData} />
-      </Group>
+      <UserDetailsAvatar userData={userData} />
+      <UserDetailsDisplayName size="lg" note={note} userData={userData} />
+      <VerifiedIcon width={14} height={14} />
+      <UserDetailsName userData={userData} />
     </UserDetailsAnchorWrapper>
     <RelativeTime note={note} />
   </Group>
 );
 
-const MobileUserDetails = ({ note, userData }) => (
-  <Group spacing={6} sx={{ alignItems: "flex-start" }}>
-    <UserDetailsAnchorWrapper note={note}>
-      <Group spacing={6} alignItems="flex-start">
+const MobileUserDetails = ({ note, userData, sx }) => {
+  const isReallySmallScreen = useMediaQuery("(max-width: 400px)");
+  const nameStyles = {
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    flex: 1,
+    maxWidth: isReallySmallScreen ? 140 : "auto",
+  };
+  const hasUserName = Boolean(userData?.name);
+
+  return (
+    <Group
+      spacing={6}
+      sx={{ ...sx, alignItems: hasUserName ? "flex-start" : "center" }}
+    >
+      <UserDetailsAnchorWrapper note={note}>
         <UserDetailsAvatar userData={userData} />
-        <Stack spacing={0}>
+        <Stack spacing={0} sx={{ overflow: "hidden" }}>
           <Group spacing={6}>
-            <UserDetailsDisplayName size="sm" note={note} userData={userData} />
+            <UserDetailsDisplayName
+              size="sm"
+              note={note}
+              userData={userData}
+              sx={nameStyles}
+            />
             <VerifiedIcon width={14} height={14} />
           </Group>
-          <UserDetailsName userData={userData} />
+          <UserDetailsName userData={userData} sx={nameStyles} />
         </Stack>
-      </Group>
-    </UserDetailsAnchorWrapper>
-    <RelativeTime note={note} mt={1} />
-  </Group>
-);
+      </UserDetailsAnchorWrapper>
+      <RelativeTime note={note} mt={hasUserName ? 1 : 0} />
+    </Group>
+  );
+};
 
 const NoteHeader = ({
   note,
@@ -88,9 +112,13 @@ const NoteHeader = ({
   const UserDetails = isSmallScreen ? MobileUserDetails : DesktopUserDetails;
 
   return (
-    <Group position="apart">
-      <UserDetails note={note} userData={userData} />
-      <Group position="right">
+    <Group position="apart" sx={{ flexWrap: "nowrap" }}>
+      <UserDetails
+        note={note}
+        userData={userData}
+        sx={{ flexWrap: "nowrap", overflow: "hidden" }}
+      />
+      <Group position="right" sx={{ minWidth: 68 }}>
         <DownloadSoundButton
           href={downloadUrl}
           downloadStatus={downloadStatus}
@@ -98,8 +126,8 @@ const NoteHeader = ({
         />
         <Center
           sx={(theme) => ({
-            width: 28,
-            height: 28,
+            width: 24,
+            height: 24,
             color: theme.colors.gray[2],
           })}
         >

--- a/utils/common.ts
+++ b/utils/common.ts
@@ -1,0 +1,1 @@
+export const noop = () => {};


### PR DESCRIPTION
This PR should fix the overlapping notes and relative time sometimes not correctly positioned issues on the home feed on small mobile screens.

![Screenshot 2023-06-04 at 11 33 48 PM](https://github.com/stemstr/Client/assets/3655410/c2e5a83b-a02e-4ee7-993e-417f8cdc04c4)

![Screenshot 2023-06-04 at 11 33 40 PM](https://github.com/stemstr/Client/assets/3655410/2ca121ef-b27d-4364-86a2-cbfd2a3c655c)

I didn't update the DiscoverFeed because I think it would be better to refactor and make a reusable VirtualizedFeed component and reuse that component in all the different feeds. I can work on that tomorrow.