### PR TITLE
refactor note

### DIFF
--- a/components/DiscoverFeed/DiscoverFeed.tsx
+++ b/components/DiscoverFeed/DiscoverFeed.tsx
@@ -5,6 +5,7 @@ import AutoSizer from "react-virtualized-auto-sizer";
 import { Box } from "@mantine/core";
 import DiscoverFeedChips from "components/DiscoverFeedChips/DiscoverFeedChips";
 import { useDiscoverFeed } from "ndk/hooks/useDiscoverFeed";
+import { EventProvider } from "../../ndk/NDKEventProvider";
 
 export default function DiscoverFeed() {
   const headerHeight = 68;
@@ -56,7 +57,9 @@ export default function DiscoverFeed() {
             ref={rowRef}
             style={{ paddingBottom: isLastEvent ? gapSize : 0 }}
           >
-            <FeedNote key={event.id} event={event} />
+            <EventProvider event={event}>
+              <FeedNote key={event.id} />
+            </EventProvider>
           </div>
         </Box>
       );
@@ -80,7 +83,7 @@ export default function DiscoverFeed() {
             itemCount={events.length}
             itemSize={getRowHeight}
             width={width}
-            overscanCount={10}
+            overscanCount={5}
             ref={listRef}
           >
             {Row}

--- a/components/HomeFeed/HomeFeed.tsx
+++ b/components/HomeFeed/HomeFeed.tsx
@@ -5,6 +5,7 @@ import { VariableSizeList, areEqual } from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
 import { Box } from "@mantine/core";
 import { useMediaQuery } from "@mantine/hooks";
+import { EventProvider } from "../../ndk/NDKEventProvider";
 
 export default function HomeFeed() {
   const headerHeight = 68;
@@ -29,14 +30,11 @@ export default function HomeFeed() {
       const gapSize = 16;
       const topPosition = style.top + gapSize * index;
       const isLastEvent = index === events.length - 1;
-      const updateRowHeight = () => {
+
+      useEffect(() => {
         if (rowRef.current) {
           setRowHeight(index, rowRef.current.clientHeight);
         }
-      };
-
-      useEffect(() => {
-        updateRowHeight();
       }, [rowRef]);
 
       return (
@@ -55,11 +53,9 @@ export default function HomeFeed() {
             ref={rowRef}
             style={{ paddingBottom: isLastEvent ? gapSize : 0 }}
           >
-            <FeedNote
-              key={event.id}
-              event={event}
-              onUserDataLoad={updateRowHeight}
-            />
+            <EventProvider event={event}>
+              <FeedNote key={event.id} />
+            </EventProvider>
           </div>
         </Box>
       );
@@ -75,7 +71,7 @@ export default function HomeFeed() {
           itemCount={events.length}
           itemSize={getRowHeight}
           width={width}
-          overscanCount={10}
+          overscanCount={5}
           ref={listRef}
         >
           {Row}

--- a/components/Note/Note.js
+++ b/components/Note/Note.js
@@ -3,7 +3,6 @@ import { Kind } from "nostr-tools";
 import React, { useEffect, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { CommentIcon, ShakaIcon, ZapIcon } from "../../icons/StemstrIcon";
-import { useProfile } from "../../ndk/hooks/useProfile";
 import NoteTags from "../NoteTags/NoteTags";
 import NoteHeader from "../NoteHeader/NoteHeader";
 import NoteAction from "../NoteAction/NoteAction";
@@ -18,20 +17,16 @@ import { useNote } from "ndk/hooks/useNote";
 import { useNDK } from "ndk/NDKProvider";
 import { formatETag, parseEventTags } from "ndk/utils";
 import { NDKEvent } from "@nostr-dev-kit/ndk";
-import { noop } from "../../utils/common";
 
 const Note = (props) => {
   const { ndk } = useNDK();
-  const { event, type, onUserDataLoad = noop } = props;
-  const note = useNote({ event });
+  const { type } = props;
+  const note = useNote();
   const { classes } = useStyles();
   const router = useRouter();
   const dispatch = useDispatch();
   const auth = useSelector((state) => state.auth);
   const [downloadStatus, setDownloadStatus] = useState("initial");
-  const { data: userData } = useProfile({
-    pubkey: note.event.pubkey,
-  });
   const downloadUrl = useMemo(() => {
     const downloadUrlTag =
       note.event.tags?.find((tag) => tag[0] === "download_url") || null;
@@ -86,12 +81,6 @@ const Note = (props) => {
     }
   }, [note.reactions.length, auth.pk]);
 
-  useEffect(() => {
-    if (userData) {
-      onUserDataLoad();
-    }
-  }, [userData]);
-
   const handleClick = () => {
     router.push(`/thread/${note.event.id}`);
   };
@@ -99,8 +88,6 @@ const Note = (props) => {
   return (
     <Stack onClick={handleClick} sx={{ cursor: "pointer" }}>
       <NoteHeader
-        note={note}
-        userData={userData}
         downloadUrl={downloadUrl}
         downloadStatus={downloadStatus}
         setDownloadStatus={setDownloadStatus}

--- a/components/NoteAction/NoteActionMore.tsx
+++ b/components/NoteAction/NoteActionMore.tsx
@@ -1,10 +1,10 @@
 import { Button, Center, Drawer, Group, Stack, Text } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { BracketsEllipsesIcon, MoreIcon } from "icons/StemstrIcon";
-import { Note } from "ndk/types/note";
 import withStopClickPropagation from "utils/hoc/withStopClickPropagation";
+import { useEvent } from "../../ndk/NDKEventProvider";
 
-const NoteActionMore = ({ note }: { note: Note }) => {
+const NoteActionMore = () => {
   const [opened, { open, close }] = useDisclosure(false);
 
   return (
@@ -41,7 +41,7 @@ const NoteActionMore = ({ note }: { note: Note }) => {
         })}
       >
         <Stack spacing="md" mb="md">
-          <NoteActionMoreCopyRawEvent note={note} onDone={close} />
+          <NoteActionMoreCopyRawEvent onDone={close} />
         </Stack>
         <Button
           onClick={close}
@@ -68,16 +68,11 @@ const NoteActionMore = ({ note }: { note: Note }) => {
   );
 };
 
-const NoteActionMoreCopyRawEvent = ({
-  note,
-  onDone,
-}: {
-  note: Note;
-  onDone: () => void;
-}) => {
+const NoteActionMoreCopyRawEvent = ({ onDone }: { onDone: () => void }) => {
+  const { event } = useEvent();
   const handleClick = () => {
     if (navigator?.clipboard) {
-      navigator.clipboard.writeText(JSON.stringify(note.event.rawEvent()));
+      navigator.clipboard.writeText(JSON.stringify(event.rawEvent()));
       onDone();
     }
   };

--- a/components/ProfileFeed/ProfileFeed.js
+++ b/components/ProfileFeed/ProfileFeed.js
@@ -1,6 +1,7 @@
 import { Stack } from "@mantine/core";
 import { FeedNote } from "../Note/Note";
 import { useProfileFeed } from "ndk/hooks/useProfileFeed";
+import { EventProvider } from "../../ndk/NDKEventProvider";
 
 export default function ProfileFeed({ pubkey }) {
   const feed = useProfileFeed({
@@ -12,7 +13,9 @@ export default function ProfileFeed({ pubkey }) {
       {feed
         .filter((event) => !event.tags.find((tag) => tag[0] === "e"))
         .map((event) => (
-          <FeedNote key={event.id} event={event} />
+          <EventProvider key={event.id} event={event}>
+            <FeedNote />
+          </EventProvider>
         ))}
     </Stack>
   ) : (

--- a/ndk/NDKEventProvider.tsx
+++ b/ndk/NDKEventProvider.tsx
@@ -1,0 +1,25 @@
+import { createContext, type PropsWithChildren, useContext } from "react";
+import { type NDKEvent } from "@nostr-dev-kit/ndk";
+
+interface EventContextProps {
+  event: NDKEvent;
+}
+
+const EventContext = createContext<EventContextProps>({
+  event: {} as NDKEvent,
+});
+
+export const EventProvider = ({
+  children,
+  event,
+}: PropsWithChildren<EventContextProps>) => (
+  <EventContext.Provider value={{ event }}>{children}</EventContext.Provider>
+);
+
+export const useEvent = () => {
+  const context = useContext(EventContext);
+  if (context === undefined) {
+    throw new Error("useEvent must be used within an EventProvider");
+  }
+  return context;
+};

--- a/ndk/hooks/useNote.tsx
+++ b/ndk/hooks/useNote.tsx
@@ -2,9 +2,11 @@ import { useEffect, useMemo, useState } from "react";
 import { useFeed } from "./useFeed";
 import { Kind } from "nostr-tools";
 import { Note } from "ndk/types/note";
-import { NDKEvent, NDKFilter } from "@nostr-dev-kit/ndk";
+import { NDKFilter } from "@nostr-dev-kit/ndk";
+import { useEvent } from "../NDKEventProvider";
 
-export function useNote({ event }: { event: NDKEvent }) {
+export function useNote() {
+  const { event } = useEvent();
   const [note, setNote] = useState<Note>({ event: event, reactions: [] });
   const reactionsFilter = useMemo<NDKFilter>(
     () => ({

--- a/ndk/hooks/useProfile.tsx
+++ b/ndk/hooks/useProfile.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import NDK, { NDKUser } from "@nostr-dev-kit/ndk";
+import { NDKUser } from "@nostr-dev-kit/ndk";
 import { useNDK } from "ndk/NDKProvider";
 
 export function useProfile({ pubkey }: { pubkey: string }) {
@@ -16,7 +16,6 @@ export function useProfile({ pubkey }: { pubkey: string }) {
         await newUser.fetchProfile();
         setUser(newUser);
       };
-      setUser(null);
       fetchUser();
     }
   }, [pubkey, setUser]);

--- a/pages/thread/[noteId].tsx
+++ b/pages/thread/[noteId].tsx
@@ -9,6 +9,7 @@ import { useThread } from "../../ndk/hooks/useThread";
 import { NoteTreeNode } from "../../ndk/types/note";
 import { Route } from "../../enums/routes";
 import { NDKEvent } from "@nostr-dev-kit/ndk";
+import { EventProvider } from "../../ndk/NDKEventProvider";
 
 export default function ThreadPage() {
   const router = useRouter();
@@ -94,11 +95,9 @@ const NoteTree = ({
           },
         })}
       >
-        <Note
-          key={noteTreeNode.event.id}
-          event={noteTreeNode.event}
-          type={type}
-        />
+        <EventProvider event={noteTreeNode.event}>
+          <Note key={noteTreeNode.event.id} type={type} />
+        </EventProvider>
       </Box>
       {noteTreeNode.children.map((childNode) => (
         <NoteTree


### PR DESCRIPTION
Initial page load for all pages seem better with these changes. 

- reduce amount of renders on page load
- reduce prop drilling
- reduce amount of relay subscriptions on page load

I think it's possible to reduce the amount of renders on initial page load even more by moving the reactions fetching down into the NoteActionLike component. I didn't make those changes yet cause I didn't want to make this PR too big.