### PR TITLE
Make reusable virtualized feed component

### DIFF
--- a/components/ApplicationContainer/ApplicationContainer.tsx
+++ b/components/ApplicationContainer/ApplicationContainer.tsx
@@ -17,7 +17,11 @@ export const ApplicationContainer = ({
       styles={{
         root: {
           width: "100%",
-          maxWidth: router.pathname === Route.Home ? "100%" : 600,
+          maxWidth: [Route.Home, Route.Discover].includes(
+            router.pathname as Route
+          )
+            ? "100%"
+            : 600,
           height: "100vh",
           margin: "auto",
         },

--- a/components/DiscoverFeed/DiscoverFeed.tsx
+++ b/components/DiscoverFeed/DiscoverFeed.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import DiscoverFeedChips from "components/DiscoverFeedChips/DiscoverFeedChips";
 import { useDiscoverFeed } from "ndk/hooks/useDiscoverFeed";
-import Feed from "../Feed/Feed";
+import { Feed, MaxWidthContainer } from "../Feed";
 
 export default function DiscoverFeed() {
   const chipsHeight = 68;
@@ -18,11 +18,13 @@ export default function DiscoverFeed() {
 
   return (
     <>
-      <DiscoverFeedChips
-        events={feed}
-        value={selectedChip}
-        onChange={(newValue) => setSelectedChip(newValue as string)}
-      />
+      <MaxWidthContainer>
+        <DiscoverFeedChips
+          events={feed}
+          value={selectedChip}
+          onChange={(newValue) => setSelectedChip(newValue as string)}
+        />
+      </MaxWidthContainer>
       <Feed events={events} heightOffset={chipsHeight} />
     </>
   );

--- a/components/DiscoverFeed/DiscoverFeed.tsx
+++ b/components/DiscoverFeed/DiscoverFeed.tsx
@@ -1,14 +1,9 @@
-import { useRef, useEffect, memo, useState } from "react";
-import { FeedNote } from "../Note/Note";
-import { VariableSizeList, areEqual } from "react-window";
-import AutoSizer from "react-virtualized-auto-sizer";
-import { Box } from "@mantine/core";
+import { useState } from "react";
 import DiscoverFeedChips from "components/DiscoverFeedChips/DiscoverFeedChips";
 import { useDiscoverFeed } from "ndk/hooks/useDiscoverFeed";
-import { EventProvider } from "../../ndk/NDKEventProvider";
+import Feed from "../Feed/Feed";
 
 export default function DiscoverFeed() {
-  const headerHeight = 68;
   const chipsHeight = 68;
   const [selectedChip, setSelectedChip] = useState("");
   const feed = useDiscoverFeed({
@@ -20,52 +15,6 @@ export default function DiscoverFeed() {
       (event) =>
         !selectedChip || event.tags.some((tag) => tag[1] === selectedChip)
     );
-  const listRef = useRef<VariableSizeList>(null);
-  const rowHeights = useRef<number[]>([]);
-  const getRowHeight = (index: number) => rowHeights.current[index] || 200;
-  const setRowHeight = (index: number, height: number) => {
-    listRef.current?.resetAfterIndex(0);
-    rowHeights.current = { ...rowHeights.current, [index]: height };
-  };
-  const Row = memo(
-    ({ index, style }: { index: number; style: Record<string, any> }) => {
-      const rowRef = useRef<HTMLDivElement>(null);
-      const event = events[index];
-      const gapSize = 16;
-      const topPosition = style.top + gapSize * index;
-      const isLastEvent = index === events.length - 1;
-
-      useEffect(() => {
-        if (rowRef.current) {
-          setRowHeight(index, rowRef.current.clientHeight);
-        }
-      }, [rowRef]);
-
-      return (
-        <Box
-          m="auto"
-          pl="md"
-          pr="md"
-          sx={{
-            ...style,
-            top: topPosition,
-            right: 0,
-            maxWidth: 600,
-          }}
-        >
-          <div
-            ref={rowRef}
-            style={{ paddingBottom: isLastEvent ? gapSize : 0 }}
-          >
-            <EventProvider event={event}>
-              <FeedNote key={event.id} />
-            </EventProvider>
-          </div>
-        </Box>
-      );
-    },
-    areEqual
-  );
 
   return (
     <>
@@ -74,22 +23,7 @@ export default function DiscoverFeed() {
         value={selectedChip}
         onChange={(newValue) => setSelectedChip(newValue as string)}
       />
-      <AutoSizer
-        style={{ height: `calc(100vh - ${headerHeight}px - ${chipsHeight}px` }}
-      >
-        {({ height, width }: { height: number; width: number }) => (
-          <VariableSizeList
-            height={height - 164}
-            itemCount={events.length}
-            itemSize={getRowHeight}
-            width={width}
-            overscanCount={2}
-            ref={listRef}
-          >
-            {Row}
-          </VariableSizeList>
-        )}
-      </AutoSizer>
+      <Feed events={events} heightOffset={chipsHeight} />
     </>
   );
 }

--- a/components/DiscoverFeedChips/DiscoverFeedChips.styles.js
+++ b/components/DiscoverFeedChips/DiscoverFeedChips.styles.js
@@ -1,6 +1,6 @@
 import { createStyles } from "@mantine/core";
 
-const useStyles = createStyles((theme, _params, getRef) => ({
+const useStyles = createStyles((theme, _params) => ({
   box: {
     overflowX: "scroll",
     "::-webkit-scrollbar": {
@@ -12,8 +12,6 @@ const useStyles = createStyles((theme, _params, getRef) => ({
     top: 0,
     backgroundColor: theme.colors.dark[7],
     zIndex: 1,
-    paddingLeft: theme.spacing.md,
-    paddingRight: theme.spacing.md,
   },
   chipGroup: {
     paddingTop: theme.spacing.md,

--- a/components/Feed/Feed.tsx
+++ b/components/Feed/Feed.tsx
@@ -1,0 +1,84 @@
+import { useRef, useEffect, memo } from "react";
+import { FeedNote } from "../Note/Note";
+import { VariableSizeList, areEqual } from "react-window";
+import AutoSizer from "react-virtualized-auto-sizer";
+import { Box } from "@mantine/core";
+import { useMediaQuery } from "@mantine/hooks";
+import { EventProvider } from "../../ndk/NDKEventProvider";
+import { type NDKEvent } from "@nostr-dev-kit/ndk";
+
+interface FeedProps {
+  events: NDKEvent[];
+  heightOffset?: number;
+}
+
+export default function Feed({ events, heightOffset = 0 }: FeedProps) {
+  const headerHeight = 68;
+  const footerHeight = useMediaQuery("(max-width: 480px)") ? 64 : 96;
+  const listRef = useRef<VariableSizeList>(null);
+  const rowHeights = useRef<number[]>([]);
+  const getRowHeight = (index: number) => rowHeights.current[index] || 200;
+  const setRowHeight = (index: number, height: number) => {
+    listRef.current?.resetAfterIndex(0);
+    rowHeights.current = { ...rowHeights.current, [index]: height };
+  };
+
+  const Row = memo(
+    ({ index, style }: { index: number; style: Record<string, any> }) => {
+      const rowRef = useRef<HTMLDivElement>(null);
+      const event = events[index];
+      const gapSize = 16;
+      const topPosition = style.top + gapSize * index;
+      const isLastEvent = index === events.length - 1;
+
+      useEffect(() => {
+        if (rowRef.current) {
+          setRowHeight(index, rowRef.current.clientHeight);
+        }
+      }, [rowRef]);
+
+      return (
+        <Box
+          m="auto"
+          pl="md"
+          pr="md"
+          sx={{
+            ...style,
+            top: topPosition,
+            right: 0,
+            maxWidth: 600,
+          }}
+        >
+          <div
+            ref={rowRef}
+            style={{ paddingBottom: isLastEvent ? gapSize : 0 }}
+          >
+            <EventProvider event={event}>
+              <FeedNote key={event.id} />
+            </EventProvider>
+          </div>
+        </Box>
+      );
+    },
+    areEqual
+  );
+
+  return (
+    <AutoSizer
+      style={{ height: `calc(100vh - ${headerHeight}px - ${heightOffset}px` }}
+    >
+      {({ height, width }: { height: number; width: number }) => (
+        <VariableSizeList
+          height={height - headerHeight - heightOffset - footerHeight}
+          itemCount={events.length}
+          itemSize={getRowHeight}
+          width={width}
+          overscanCount={2}
+          ref={listRef}
+        >
+          {Row}
+        </VariableSizeList>
+      )}
+    </AutoSizer>
+  );
+}

--- a/components/Feed/Feed.tsx
+++ b/components/Feed/Feed.tsx
@@ -12,7 +12,7 @@ interface FeedProps {
   heightOffset?: number;
 }
 
-export default function Feed({ events, heightOffset = 0 }: FeedProps) {
+export function Feed({ events, heightOffset = 0 }: FeedProps) {
   const headerHeight = 68;
   const footerHeight = useMediaQuery("(max-width: 480px)") ? 64 : 96;
   const listRef = useRef<VariableSizeList>(null);

--- a/components/Feed/MaxWidthContainer.tsx
+++ b/components/Feed/MaxWidthContainer.tsx
@@ -1,0 +1,10 @@
+import { type PropsWithChildren } from "react";
+import { Box } from "@mantine/core";
+
+export function MaxWidthContainer({ children }: PropsWithChildren<{}>) {
+  return (
+    <Box m="auto" pl="md" pr="md" w="100%" sx={{ maxWidth: 600 }}>
+      {children}
+    </Box>
+  );
+}

--- a/components/Feed/index.tsx
+++ b/components/Feed/index.tsx
@@ -1,0 +1,2 @@
+export * from "./Feed";
+export * from "./MaxWidthContainer";

--- a/components/HomeFeed/HomeFeed.tsx
+++ b/components/HomeFeed/HomeFeed.tsx
@@ -1,5 +1,5 @@
 import { useHomeFeed } from "ndk/hooks/useHomeFeed";
-import Feed from "../Feed/Feed";
+import { Feed } from "../Feed";
 
 export default function HomeFeed() {
   const feed = useHomeFeed();

--- a/components/HomeFeed/HomeFeed.tsx
+++ b/components/HomeFeed/HomeFeed.tsx
@@ -1,82 +1,11 @@
-import { useRef, useEffect, memo } from "react";
-import { FeedNote } from "../Note/Note";
 import { useHomeFeed } from "ndk/hooks/useHomeFeed";
-import { VariableSizeList, areEqual } from "react-window";
-import AutoSizer from "react-virtualized-auto-sizer";
-import { Box } from "@mantine/core";
-import { useMediaQuery } from "@mantine/hooks";
-import { EventProvider } from "../../ndk/NDKEventProvider";
+import Feed from "../Feed/Feed";
 
 export default function HomeFeed() {
-  const headerHeight = 68;
-  const footerHeight = useMediaQuery("(max-width: 480px)") ? 64 : 96;
   const feed = useHomeFeed();
   const events = feed.filter(
     (event) => !event.tags.find((tag) => tag[0] === "e")
   );
 
-  const listRef = useRef<VariableSizeList>(null);
-  const rowHeights = useRef<number[]>([]);
-  const getRowHeight = (index: number) => rowHeights.current[index] || 200;
-  const setRowHeight = (index: number, height: number) => {
-    listRef.current?.resetAfterIndex(0);
-    rowHeights.current = { ...rowHeights.current, [index]: height };
-  };
-
-  const Row = memo(
-    ({ index, style }: { index: number; style: Record<string, any> }) => {
-      const rowRef = useRef<HTMLDivElement>(null);
-      const event = events[index];
-      const gapSize = 16;
-      const topPosition = style.top + gapSize * index;
-      const isLastEvent = index === events.length - 1;
-
-      useEffect(() => {
-        if (rowRef.current) {
-          setRowHeight(index, rowRef.current.clientHeight);
-        }
-      }, [rowRef]);
-
-      return (
-        <Box
-          m="auto"
-          pl="md"
-          pr="md"
-          sx={{
-            ...style,
-            top: topPosition,
-            right: 0,
-            maxWidth: 600,
-          }}
-        >
-          <div
-            ref={rowRef}
-            style={{ paddingBottom: isLastEvent ? gapSize : 0 }}
-          >
-            <EventProvider event={event}>
-              <FeedNote key={event.id} />
-            </EventProvider>
-          </div>
-        </Box>
-      );
-    },
-    areEqual
-  );
-
-  return (
-    <AutoSizer style={{ height: `calc(100vh - ${headerHeight}px` }}>
-      {({ height, width }: { height: number; width: number }) => (
-        <VariableSizeList
-          height={height - headerHeight - footerHeight}
-          itemCount={events.length}
-          itemSize={getRowHeight}
-          width={width}
-          overscanCount={2}
-          ref={listRef}
-        >
-          {Row}
-        </VariableSizeList>
-      )}
-    </AutoSizer>
-  );
+  return <Feed events={events} />;
 }

--- a/pages/discover.tsx
+++ b/pages/discover.tsx
@@ -1,7 +1,8 @@
-import { Box, Stack } from "@mantine/core";
+import { Stack } from "@mantine/core";
 import Head from "next/head";
 import DiscoverFeedHeader from "components/DiscoverFeedHeader/DiscoverFeedHeader";
 import DiscoverFeed from "components/DiscoverFeed/DiscoverFeed";
+import { MaxWidthContainer } from "../components/Feed";
 
 export default function HomePage() {
   return (
@@ -10,9 +11,9 @@ export default function HomePage() {
         <title>Stemstr - Discover</title>
       </Head>
       <Stack spacing={0}>
-        <Box m="auto" pl="md" pr="md" w="100%" sx={{ maxWidth: 600 }}>
+        <MaxWidthContainer>
           <DiscoverFeedHeader />
-        </Box>
+        </MaxWidthContainer>
         <DiscoverFeed />
       </Stack>
     </>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Stack } from "@mantine/core";
+import { Stack } from "@mantine/core";
 import Head from "next/head";
 import HomeFeed from "../components/HomeFeed/HomeFeed";
 import HomeFeedHeader from "../components/HomeFeedHeader/HomeFeedHeader";
@@ -7,6 +7,7 @@ import { AppState } from "store/Store";
 import { useEffect } from "react";
 import { useRouter } from "next/router";
 import { Route } from "enums";
+import { MaxWidthContainer } from "../components/Feed";
 
 export default function HomePage() {
   const authState = useSelector((state: AppState) => state.auth);
@@ -25,9 +26,9 @@ export default function HomePage() {
       </Head>
       {/* <ColorSchemeToggle /> */}
       <Stack spacing={0}>
-        <Box m="auto" pl="md" pr="md" w="100%" sx={{ maxWidth: 600 }}>
+        <MaxWidthContainer>
           <HomeFeedHeader />
-        </Box>
+        </MaxWidthContainer>
         <HomeFeed />
       </Stack>
     </>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,14 +12,15 @@ import { MaxWidthContainer } from "../components/Feed";
 export default function HomePage() {
   const authState = useSelector((state: AppState) => state.auth);
   const router = useRouter();
+  const willRedirect = !authState.type;
 
   useEffect(() => {
-    if (!authState.type) {
+    if (willRedirect) {
       router.push(Route.Discover);
     }
-  }, [authState.type]);
+  }, [willRedirect]);
 
-  return (
+  return willRedirect ? null : (
     <>
       <Head>
         <title>Stemstr - Home</title>


### PR DESCRIPTION
Moar refactoring, made the scrolling UX the same on the discovery page as it is on the home page, and fixed the discovery feed not loading bug when not logged in.

resolves https://github.com/stemstr/Client/issues/89