### PR TITLE
improve mobile note loading

### DIFF
--- a/components/NoteHeader/NoteHeader.js
+++ b/components/NoteHeader/NoteHeader.js
@@ -115,10 +115,14 @@ const MobileUserDetails = ({ userData, sx }) => {
 };
 
 const UserDetails = ({ userData, sx }) => {
-  const viewportWidth = document.documentElement.clientWidth < 600;
-  const isSmallScreen = useMediaQuery("(max-width: 600px)", viewportWidth, {
-    getInitialValueInEffect: !viewportWidth,
-  });
+  const isScreenSmallOnInitialLoad = document.documentElement.clientWidth < 600;
+  const isSmallScreen = useMediaQuery(
+    "(max-width: 600px)",
+    isScreenSmallOnInitialLoad,
+    {
+      getInitialValueInEffect: !isScreenSmallOnInitialLoad,
+    }
+  );
   const UserDetailsComponent = isSmallScreen
     ? MobileUserDetails
     : DesktopUserDetails;

--- a/components/NoteHeader/NoteHeader.js
+++ b/components/NoteHeader/NoteHeader.js
@@ -115,7 +115,7 @@ const MobileUserDetails = ({ userData, sx }) => {
 };
 
 const UserDetails = ({ userData, sx }) => {
-  const viewportWidth = document.documentElement.clientWidth;
+  const viewportWidth = document.documentElement.clientWidth < 600;
   const isSmallScreen = useMediaQuery("(max-width: 600px)", viewportWidth, {
     getInitialValueInEffect: !viewportWidth,
   });

--- a/components/NoteHeader/NoteHeader.js
+++ b/components/NoteHeader/NoteHeader.js
@@ -8,6 +8,7 @@ import { getRelativeTimeString } from "../../ndk/utils";
 import NoteActionMore from "components/NoteAction/NoteActionMore";
 import { useEvent } from "../../ndk/NDKEventProvider";
 import { useProfile } from "../../ndk/hooks/useProfile";
+import { isMobileUserAgent } from "../../utils/common";
 
 const UserDetailsAnchorWrapper = ({ children }) => {
   const { event } = useEvent();
@@ -115,7 +116,14 @@ const MobileUserDetails = ({ userData, sx }) => {
 };
 
 const UserDetails = ({ userData, sx }) => {
-  const isSmallScreen = useMediaQuery("(max-width: 600px)");
+  const isPossiblyMobileDevice = isMobileUserAgent();
+  const isSmallScreen = useMediaQuery(
+    "(max-width: 600px)",
+    isPossiblyMobileDevice,
+    {
+      getInitialValueInEffect: !isPossiblyMobileDevice,
+    }
+  );
   const UserDetailsComponent = isSmallScreen
     ? MobileUserDetails
     : DesktopUserDetails;

--- a/components/NoteHeader/NoteHeader.js
+++ b/components/NoteHeader/NoteHeader.js
@@ -8,7 +8,6 @@ import { getRelativeTimeString } from "../../ndk/utils";
 import NoteActionMore from "components/NoteAction/NoteActionMore";
 import { useEvent } from "../../ndk/NDKEventProvider";
 import { useProfile } from "../../ndk/hooks/useProfile";
-import { isMobileUserAgent } from "../../utils/common";
 
 const UserDetailsAnchorWrapper = ({ children }) => {
   const { event } = useEvent();
@@ -116,14 +115,10 @@ const MobileUserDetails = ({ userData, sx }) => {
 };
 
 const UserDetails = ({ userData, sx }) => {
-  const isPossiblyMobileDevice = isMobileUserAgent();
-  const isSmallScreen = useMediaQuery(
-    "(max-width: 600px)",
-    isPossiblyMobileDevice,
-    {
-      getInitialValueInEffect: !isPossiblyMobileDevice,
-    }
-  );
+  const viewportWidth = document.documentElement.clientWidth;
+  const isSmallScreen = useMediaQuery("(max-width: 600px)", viewportWidth, {
+    getInitialValueInEffect: !viewportWidth,
+  });
   const UserDetailsComponent = isSmallScreen
     ? MobileUserDetails
     : DesktopUserDetails;

--- a/utils/common.ts
+++ b/utils/common.ts
@@ -1,1 +1,7 @@
 export const noop = () => {};
+
+export const isMobileUserAgent = () => {
+  return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+    navigator.userAgent
+  );
+};

--- a/utils/common.ts
+++ b/utils/common.ts
@@ -1,7 +1,1 @@
 export const noop = () => {};
-
-export const isMobileUserAgent = () => {
-  return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-    navigator.userAgent
-  );
-};


### PR DESCRIPTION
On first render, the app was always rendering the note headers using the styles designed for desktop. This should help prevent that.

https://mantine.dev/hooks/use-media-query/