### PR TITLE
improve initial load speed and fix discover feed

### DIFF
--- a/components/DiscoverFeed/DiscoverFeed.tsx
+++ b/components/DiscoverFeed/DiscoverFeed.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useCallback } from "react";
+import { useMemo, useState } from "react";
 import DiscoverFeedChips from "components/DiscoverFeedChips/DiscoverFeedChips";
 import { Feed, MaxWidthContainer } from "../Feed";
 import { type NDKEvent, type NDKFilter } from "@nostr-dev-kit/ndk";
@@ -7,37 +7,21 @@ import { Kind } from "nostr-tools";
 export default function DiscoverFeed() {
   const chipsHeight = 68;
   const [selectedChip, setSelectedChip] = useState("");
-  const [chipLabels, setChipLabels] = useState<string[]>([]);
-  const chipLabelsHash = chipLabels.join();
+  const [events, setEvents] = useState<NDKEvent[]>([]);
   const filter = useMemo<NDKFilter>(
     () => ({
       kinds: [1, 1808 as Kind],
+      limit: 50,
       "#t": selectedChip ? [selectedChip] : undefined,
     }),
     [selectedChip]
-  );
-  const handleOnEventsLoaded = useCallback(
-    (events: NDKEvent[]) => {
-      const tagNames: string[] = [];
-
-      events.forEach(({ tags }) => {
-        tags.forEach((tag) => {
-          if (tag[0] === "t") {
-            tagNames.push(tag[1]);
-          }
-        });
-      });
-
-      setChipLabels(Array.from(new Set([...chipLabels, ...tagNames])));
-    },
-    [chipLabelsHash]
   );
 
   return (
     <>
       <MaxWidthContainer>
         <DiscoverFeedChips
-          labels={chipLabels}
+          events={events}
           value={selectedChip}
           onChange={(newValue) => setSelectedChip(newValue as string)}
         />
@@ -45,7 +29,7 @@ export default function DiscoverFeed() {
       <Feed
         filter={filter}
         heightOffset={chipsHeight}
-        onEventsLoaded={handleOnEventsLoaded}
+        onEventsLoaded={setEvents}
       />
     </>
   );

--- a/components/DiscoverFeedChips/DiscoverFeedChips.tsx
+++ b/components/DiscoverFeedChips/DiscoverFeedChips.tsx
@@ -1,16 +1,34 @@
 import { Box, Chip } from "@mantine/core";
 import useStyles from "./DiscoverFeedChips.styles";
+import { useEffect, useState } from "react";
+import { NDKEvent } from "@nostr-dev-kit/ndk";
 
 export default function DiscoverFeedChips({
-  labels,
+  events,
   value,
   onChange,
 }: {
-  labels: string[];
+  events: NDKEvent[];
   value: string;
   onChange: (value: string | string[]) => void;
 }) {
   const { classes } = useStyles();
+  const [chipLabels, setChipLabels] = useState<string[]>([]);
+  const chipLabelsHash = chipLabels.join();
+
+  useEffect(() => {
+    const tagNames: string[] = [];
+
+    events.forEach(({ tags }) => {
+      tags.forEach((tag) => {
+        if (tag[0] === "t") {
+          tagNames.push(tag[1]);
+        }
+      });
+    });
+
+    setChipLabels(Array.from(new Set([...chipLabels, ...tagNames])));
+  }, [events, chipLabelsHash]);
 
   return (
     <Box className={classes.box}>
@@ -21,7 +39,7 @@ export default function DiscoverFeedChips({
         position="left"
         className={classes.chipGroup}
       >
-        {["🔥 Latest", ...labels].map((chipName, index) => (
+        {["🔥 Latest", ...chipLabels].map((chipName, index) => (
           <Chip
             key={index}
             value={index === 0 ? "" : chipName}

--- a/components/Feed/Feed.tsx
+++ b/components/Feed/Feed.tsx
@@ -70,10 +70,10 @@ export const Feed = memo(
 
     FeedRow.displayName = "FeedRow";
 
-    // only preload the profiles for the first 100 events to reduce amount of data fetched and since relays don't return
+    // only preload the profiles for the first 50 events to reduce amount of data fetched and since relays don't return
     // any results when requesting too many profiles
     const hasAttemptedProfileCachePreload = usePreloadProfileCache(
-      events.slice(0, 100).map(({ pubkey }) => pubkey)
+      events.slice(0, 50).map(({ pubkey }) => pubkey)
     );
 
     const processEvents = useCallback(

--- a/components/HomeFeed/HomeFeed.tsx
+++ b/components/HomeFeed/HomeFeed.tsx
@@ -10,6 +10,7 @@ export default function HomeFeed() {
   const filter = useMemo<NDKFilter>(
     () => ({
       kinds: [1, 1808 as Kind],
+      limit: 50,
       authors: pubkeys,
     }),
     [pubkeyHash]


### PR DESCRIPTION
improved the initial load speed and fixed a bug with the discover feed where the whole feed would re-render when scrolling way down and loading older notes.