### PR TITLE
Add default zap wallet selection

### DIFF
--- a/components/ApplicationContainer/ApplicationContainer.tsx
+++ b/components/ApplicationContainer/ApplicationContainer.tsx
@@ -1,15 +1,18 @@
-import { AppShell, Box } from "@mantine/core";
+import { AppShell } from "@mantine/core";
 import { useRouter } from "next/router";
 
 import BottomNavigation from "../BottomNavigation/BottomNavigation";
 import PostSheet from "../PostSheet/PostSheet";
 import FileDropOverlay from "../FileDropOverlay/FileDropOverlay";
 import { Route } from "enums/routes";
+import useLoadUserPreferences from "../../ndk/hooks/useLoadUserPreferences";
 
 export const ApplicationContainer = ({
   children,
 }: React.PropsWithChildren<{}>) => {
   const router = useRouter();
+
+  useLoadUserPreferences();
 
   return (
     <AppShell

--- a/components/Settings/SettingDefaultZapWallet.tsx
+++ b/components/Settings/SettingDefaultZapWallet.tsx
@@ -28,6 +28,9 @@ export function SettingDefaultZapWallet() {
       ...userPreferences,
       defaultLightningWallet: value,
     };
+
+    dispatch(setUserPreferences(unencryptedContent));
+
     const customAppDataEvent = createAppDataEventTemplate({
       ndk,
       content: await ndk.signer.encrypt(
@@ -36,10 +39,7 @@ export function SettingDefaultZapWallet() {
       ),
     });
 
-    customAppDataEvent
-      .publish(stemstrRelaySet)
-      .then(() => dispatch(setUserPreferences(unencryptedContent)))
-      .catch(console.error);
+    customAppDataEvent.publish(stemstrRelaySet).catch(console.error);
   };
 
   return (

--- a/components/Settings/SettingDefaultZapWallet.tsx
+++ b/components/Settings/SettingDefaultZapWallet.tsx
@@ -1,0 +1,23 @@
+import { Select } from "@mantine/core";
+import SettingsItem from "./SettingsItem";
+import { WalletIcon } from "icons/StemstrIcon";
+import { DEFAULT_LIGHTNING_WALLETS } from "../../constants";
+
+export function SettingDefaultZapWallet() {
+  // TODO: load saved default wallet and save default wallet on selection using nip-78
+
+  return (
+    <SettingsItem
+      Icon={WalletIcon}
+      title="Default zap wallet"
+      description={
+        <Select
+          placeholder="Select wallet"
+          data={Object.entries(DEFAULT_LIGHTNING_WALLETS).map(
+            ([value, { displayName }]) => ({ value, label: displayName })
+          )}
+        />
+      }
+    />
+  );
+}

--- a/components/Settings/SettingDefaultZapWallet.tsx
+++ b/components/Settings/SettingDefaultZapWallet.tsx
@@ -5,15 +5,18 @@ import { DEFAULT_LIGHTNING_WALLETS } from "../../constants";
 import { useNDK } from "../../ndk/NDKProvider";
 import useCurrentUser from "../../hooks/useCurrentUser";
 import { createAppDataEventTemplate } from "../../ndk/utils";
-import { useDispatch } from "react-redux";
-import { type UserPreferences, setUserPreferences } from "../../store/Nip78";
-import useUserPreferences from "../../ndk/hooks/useUserPreferences";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  type UserPreferences,
+  setUserPreferences,
+  selectNip78State,
+} from "../../store/Nip78";
 
 export function SettingDefaultZapWallet() {
   const { ndk, stemstrRelaySet } = useNDK();
   const dispatch = useDispatch();
   const currentUser = useCurrentUser();
-  const userPreferences = useUserPreferences();
+  const { userPreferences } = useSelector(selectNip78State);
   const handleChange = async (
     value: keyof typeof DEFAULT_LIGHTNING_WALLETS
   ) => {

--- a/components/Settings/SettingsItem.tsx
+++ b/components/Settings/SettingsItem.tsx
@@ -1,5 +1,5 @@
 import { Anchor, Box, Group, Stack, Text } from "@mantine/core";
-import { MouseEventHandler } from "react";
+import { type MouseEventHandler, type ReactNode } from "react";
 import useStyles from "components/Settings/Settings.styles";
 import { ChevronRightIcon } from "icons/StemstrIcon";
 import Link from "next/link";
@@ -7,7 +7,7 @@ import Link from "next/link";
 export type SettingsItemProps = {
   Icon: (props: any) => JSX.Element;
   title: string;
-  description: string;
+  description: ReactNode;
   href?: string;
   onClick?: MouseEventHandler<HTMLDivElement>;
   extra?: JSX.Element;

--- a/components/ZapWizard/InvoiceDrawer.tsx
+++ b/components/ZapWizard/InvoiceDrawer.tsx
@@ -26,6 +26,7 @@ import {
   updateZapsAmountTotal,
 } from "../../store/Notes";
 import useAuth from "../../hooks/useAuth";
+import useLightningWalletUri from "../../hooks/useLightningWalletUri";
 
 interface InvoiceDrawerProps {
   isOpen: boolean;
@@ -47,6 +48,7 @@ const InvoiceDrawer = ({
   const dispatch = useDispatch();
   const { ndk } = useNDK();
   const { zapRecipient, willShowCloseButton, zappedEvent } = useZapWizard();
+  const lightningWalletUri = useLightningWalletUri(invoice);
   const [isPayWithWalletButtonLoading, setIsPayWithWalletButtonLoading] =
     useState(false);
   const zapRecipientHexPubkey = zapRecipient.hexpubkey();
@@ -99,7 +101,7 @@ const InvoiceDrawer = ({
 
         setIsPayWithWalletButtonLoading(false);
       } else if (!isDesktop) {
-        window.location.href = `lightning:${invoice}`;
+        window.location.href = lightningWalletUri;
       }
     };
 

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,1 +1,2 @@
 export * from "./nostr";
+export * from "./lightning";

--- a/constants/lightning.ts
+++ b/constants/lightning.ts
@@ -1,0 +1,27 @@
+export const DEFAULT_LIGHTNING_WALLETS = {
+  strike: { displayName: "Strike", uriPrefix: "strike:lightning:" },
+  cashapp: {
+    displayName: "Cash App",
+    uriPrefix: "https://cash.app/launch/lightning/",
+  },
+  muun: { displayName: "Muun", uriPrefix: "muun:" },
+  bluewallet: {
+    displayName: "Blue Wallet",
+    uriPrefix: "bluewallet:lightning:",
+  },
+  walletofsatoshi: {
+    displayName: "Wallet of Satoshi",
+    uriPrefix: "walletofsatoshi:lightning:",
+  },
+  zebedee: { displayName: "Zebedee", uriPrefix: "zebedee:lightning:" },
+  zeusln: { displayName: "Zeus LN", uriPrefix: "zeusln:lightning:" },
+  lnlink: { displayName: "LNLink", uriPrefix: "lnlink:lightning:" },
+  phoenix: { displayName: "Phoenix", uriPrefix: "phoenix://" },
+  breez: { displayName: "Breez", uriPrefix: "breez:" },
+  bitcoinbeach: { displayName: "Bitcoin Beach", uriPrefix: "bitcoinbeach://" },
+  blixtwallet: {
+    displayName: "Blixt Wallet",
+    uriPrefix: "blixtwallet:lightning:",
+  },
+  river: { displayName: "River", uriPrefix: "river://" },
+};

--- a/hooks/useCurrentUser.tsx
+++ b/hooks/useCurrentUser.tsx
@@ -1,0 +1,9 @@
+import { useSelector } from "react-redux";
+import { AppState } from "../store/Store";
+import { useUser } from "../ndk/hooks/useUser";
+
+export default function useCurrentUser() {
+  const authState = useSelector((state: AppState) => state.auth);
+
+  return useUser(authState.pk);
+}

--- a/hooks/useLightningWalletUri.tsx
+++ b/hooks/useLightningWalletUri.tsx
@@ -1,0 +1,12 @@
+import { useSelector } from "react-redux";
+import { selectNip78State } from "../store/Nip78";
+import { DEFAULT_LIGHTNING_WALLETS } from "../constants";
+
+export default function useLightningWalletUri(invoice: string) {
+  const { userPreferences } = useSelector(selectNip78State);
+  const { uriPrefix = "lightning:" } = userPreferences.defaultLightningWallet
+    ? DEFAULT_LIGHTNING_WALLETS[userPreferences.defaultLightningWallet]
+    : {};
+
+  return `${uriPrefix}${invoice}`;
+}

--- a/ndk/hooks/useLoadUserPreferences.tsx
+++ b/ndk/hooks/useLoadUserPreferences.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { isDesktop } from "react-device-detect";
 import { selectNip78State } from "../../store/Nip78";
 import { useNDK } from "../NDKProvider";
 import { NDKEvent, NDKKind } from "@nostr-dev-kit/ndk";
@@ -21,7 +22,8 @@ export default function useLoadUserPreferences() {
       hasCompletedInitialFetch ||
       !ndk ||
       !currentUser ||
-      isFetching.current
+      isFetching.current ||
+      isDesktop // currently, only need to fetch user preferences on mobile
     ) {
       return;
     }

--- a/ndk/hooks/useLoadUserPreferences.tsx
+++ b/ndk/hooks/useLoadUserPreferences.tsx
@@ -9,10 +9,9 @@ import {
   setHasCompletedInitialFetch,
 } from "../../store/Nip78";
 
-export default function useUserPreferences() {
+export default function useLoadUserPreferences() {
   const { ndk, stemstrRelaySet } = useNDK();
-  const { userPreferences, hasCompletedInitialFetch } =
-    useSelector(selectNip78State);
+  const { hasCompletedInitialFetch } = useSelector(selectNip78State);
   const dispatch = useDispatch();
   const currentUser = useCurrentUser();
   const isFetching = useRef(false);
@@ -66,6 +65,4 @@ export default function useUserPreferences() {
         isFetching.current = false;
       });
   }, [hasCompletedInitialFetch, ndk, currentUser, stemstrRelaySet, dispatch]);
-
-  return userPreferences;
 }

--- a/ndk/hooks/useUserPreferences.tsx
+++ b/ndk/hooks/useUserPreferences.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { selectNip78State } from "../../store/Nip78";
+import { useNDK } from "../NDKProvider";
+import { NDKEvent, NDKKind } from "@nostr-dev-kit/ndk";
+import useCurrentUser from "../../hooks/useCurrentUser";
+import {
+  setUserPreferences,
+  setHasCompletedInitialFetch,
+} from "../../store/Nip78";
+
+export default function useUserPreferences() {
+  const { ndk, stemstrRelaySet } = useNDK();
+  const { userPreferences, hasCompletedInitialFetch } =
+    useSelector(selectNip78State);
+  const dispatch = useDispatch();
+  const currentUser = useCurrentUser();
+  const isFetching = useRef(false);
+
+  useEffect(() => {
+    if (
+      hasCompletedInitialFetch ||
+      !ndk ||
+      !currentUser ||
+      isFetching.current
+    ) {
+      return;
+    }
+
+    isFetching.current = true;
+
+    const storeNip78State = async (event: NDKEvent) => {
+      if (!ndk?.signer || !currentUser) {
+        return;
+      }
+
+      try {
+        dispatch(setHasCompletedInitialFetch(true));
+        dispatch(
+          setUserPreferences(
+            JSON.parse(await ndk.signer.decrypt(currentUser, event.content))
+          )
+        );
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    ndk
+      .fetchEvent(
+        {
+          kinds: [NDKKind.AppSpecificData],
+          authors: [currentUser.hexpubkey()],
+        },
+        {},
+        // @ts-expect-error TODO: remove this type is fixed NDK https://github.com/nostr-dev-kit/ndk/issues/51
+        stemstrRelaySet
+      )
+      .then((event: NDKEvent | null) => {
+        if (event) {
+          return storeNip78State(event);
+        }
+      })
+      .catch(console.error)
+      .finally(() => {
+        isFetching.current = false;
+      });
+  }, [hasCompletedInitialFetch, ndk, currentUser, stemstrRelaySet, dispatch]);
+
+  return userPreferences;
+}

--- a/ndk/utils.tsx
+++ b/ndk/utils.tsx
@@ -6,6 +6,7 @@ import NDK, {
   NDKUser,
   NDKUserProfile,
   NostrEvent,
+  NDKKind,
 } from "@nostr-dev-kit/ndk";
 import {
   nip19,
@@ -452,4 +453,47 @@ export const extractMentionPubkeys = (event: NDKEvent) => {
   });
 
   return pubkeys;
+};
+
+interface CreateEventTemplateParams {
+  ndk: NDK;
+  kind: NDKKind;
+  content?: string;
+  tags?: NDKTag[];
+}
+
+export const createEventTemplate = ({
+  ndk,
+  kind,
+  content = "",
+  tags,
+}: CreateEventTemplateParams) => {
+  const eventTemplate = new NDKEvent(ndk);
+
+  eventTemplate.kind = kind;
+  eventTemplate.created_at = Math.floor(Date.now() / 1000);
+  eventTemplate.content = content;
+
+  if (tags) {
+    eventTemplate.tags = tags;
+  }
+
+  return eventTemplate;
+};
+
+export const createAppDataEventTemplate = ({
+  ndk,
+  content,
+}: {
+  ndk: NDK;
+  content: string;
+}) => {
+  const eventTemplate = createEventTemplate({
+    ndk,
+    kind: NDKKind.AppSpecificData,
+    content,
+    tags: [["d", "stemstr"]],
+  });
+
+  return eventTemplate;
 };

--- a/pages/settings/index.tsx
+++ b/pages/settings/index.tsx
@@ -7,6 +7,7 @@ import useAuth from "hooks/useAuth";
 import { ChevronLeftIcon } from "icons/StemstrIcon";
 import Head from "next/head";
 import { SettingNsec } from "components/Settings/SettingNsec";
+import { SettingDefaultZapWallet } from "../../components/Settings/SettingDefaultZapWallet";
 
 export default function Settings() {
   const { guardAuth, isAuthenticated } = useAuth();
@@ -28,6 +29,7 @@ export default function Settings() {
       <Stack pt="md" pl="md" pr="md" spacing="sm" align="center">
         <SettingPubkey />
         <SettingNsec />
+        <SettingDefaultZapWallet />
         <SettingLogout />
       </Stack>
     </>

--- a/pages/settings/index.tsx
+++ b/pages/settings/index.tsx
@@ -1,3 +1,4 @@
+import { isDesktop } from "react-device-detect";
 import { Group, Stack, Text } from "@mantine/core";
 import BackButton from "components/BackButton/BackButton";
 import { SettingPubkey } from "components/Settings/SettingPubkey";
@@ -29,7 +30,8 @@ export default function Settings() {
       <Stack pt="md" pl="md" pr="md" spacing="sm" align="center">
         <SettingPubkey />
         <SettingNsec />
-        <SettingDefaultZapWallet />
+        {/* wallet chooser is only used on mobile */}
+        {!isDesktop && <SettingDefaultZapWallet />}
         <SettingLogout />
       </Stack>
     </>

--- a/store/Nip78.ts
+++ b/store/Nip78.ts
@@ -1,0 +1,35 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import { AppState } from "./Store";
+import { DEFAULT_LIGHTNING_WALLETS } from "../constants";
+
+export interface UserPreferences {
+  defaultLightningWallet?: keyof typeof DEFAULT_LIGHTNING_WALLETS;
+}
+
+interface Nip78State {
+  hasCompletedInitialFetch: boolean;
+  userPreferences: UserPreferences;
+}
+
+const initialState: Nip78State = {
+  hasCompletedInitialFetch: false,
+  userPreferences: {},
+};
+
+export const nip78Slice = createSlice({
+  name: "nip78",
+  initialState,
+  reducers: {
+    setUserPreferences: (state, action: PayloadAction<UserPreferences>) => {
+      state.userPreferences = action.payload;
+    },
+    setHasCompletedInitialFetch: (state, action: PayloadAction<boolean>) => {
+      state.hasCompletedInitialFetch = action.payload;
+    },
+  },
+});
+
+export const { setUserPreferences, setHasCompletedInitialFetch } =
+  nip78Slice.actions;
+export const selectNip78State = (state: AppState) => state.nip78;
+export default nip78Slice.reducer;

--- a/store/Store.ts
+++ b/store/Store.ts
@@ -7,6 +7,7 @@ import { relaysSlice } from "./Relays";
 import { eventsSlice } from "./Events";
 import { nip05Slice } from "./Nip05";
 import { notesSlice } from "./Notes";
+import { nip78Slice } from "./Nip78";
 
 const makeStore = () =>
   configureStore({
@@ -18,6 +19,7 @@ const makeStore = () =>
       [eventsSlice.name]: eventsSlice.reducer,
       [nip05Slice.name]: nip05Slice.reducer,
       [notesSlice.name]: notesSlice.reducer,
+      [nip78Slice.name]: nip78Slice.reducer,
     },
     devTools: true,
   });


### PR DESCRIPTION
Default wallet selector is shown on the user settings page only on mobile. I don't think it makes sense to show it on desktop since the Pay with wallet button only shows on desktop when the user is using webln and in that case it wouldn't use the default wallet that they choose. 

Once a default wallet is set on mobile, clicking the Pay with wallet button in the zap flow should open the default wallet that has been selected.