### PR TITLE
fix name not being displayed in zap flow bug

### DIFF
--- a/ndk/utils.tsx
+++ b/ndk/utils.tsx
@@ -223,7 +223,7 @@ export const getNormalizedName = (pubkey: string, user?: NDKUser) => {
   const profile = user?.profile;
 
   return (
-    profile?.displayName ?? profile?.name ?? `${pubkey.substring(0, 5)}...`
+    profile?.displayName || profile?.name || `${pubkey.substring(0, 5)}...`
   );
 };
 


### PR DESCRIPTION
displayName is sometimes set to an empty string which was causing the bug.