### PR TITLE
fix exception raised on invalid lud06

### DIFF
--- a/components/NoteActionZap/NoteActionZap.tsx
+++ b/components/NoteActionZap/NoteActionZap.tsx
@@ -71,10 +71,16 @@ const NoteActionContentWithZapWizard = () => {
 const NoteActionZap = () => {
   const { event } = useEvent();
   const zapRecipient = useUser(event.pubkey);
-  const isZappable =
-    zapRecipient && getLnurlServiceEndpoint(zapRecipient.profile, event);
+  let isZappable = false as boolean | undefined;
 
-  return isZappable ? (
+  try {
+    isZappable =
+      zapRecipient && !!getLnurlServiceEndpoint(zapRecipient.profile, event);
+  } catch (err) {
+    console.log(err);
+  }
+
+  return isZappable && zapRecipient ? (
     <ZapWizardProvider zapRecipient={zapRecipient} zappedEvent={event}>
       <NoteActionContentWithZapWizard />
     </ZapWizardProvider>


### PR DESCRIPTION
ndk is throwing an exception in `getZapEndpoint` when it calls [bech32.decode](https://github.com/paulmillr/scure-base/blob/4983519ddb025321c4e77b0e9c8669c5f57fc912/index.ts#L495) with invalid data (in this case "zero").

This hotfix simply wraps the operation it a try block.

![image](https://github.com/stemstr/Client/assets/4248167/43457a2f-fe45-4b62-b858-ba76b825258d)